### PR TITLE
Switch S3 integration to Yandex

### DIFF
--- a/components/aws_s3/__init__.py
+++ b/components/aws_s3/__init__.py
@@ -1,4 +1,4 @@
-"""The AWS S3 integration."""
+"""The Yandex Object Storage integration."""
 
 from __future__ import annotations
 

--- a/components/aws_s3/backup.py
+++ b/components/aws_s3/backup.py
@@ -1,4 +1,4 @@
-"""Backup platform for the AWS S3 integration."""
+"""Backup platform for the Yandex Object Storage integration."""
 
 from collections.abc import AsyncIterator, Callable, Coroutine
 import functools
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 CACHE_TTL = 300
 
 # S3 part size requirements: 5 MiB to 5 GiB per part
-# https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+# See Yandex Object Storage documentation for details.
 # We set the threshold to 20 MiB to avoid too many parts.
 # Note that each part is allocated in the memory.
 MULTIPART_MIN_PART_SIZE_BYTES = 20 * 2**20

--- a/components/aws_s3/const.py
+++ b/components/aws_s3/const.py
@@ -1,4 +1,4 @@
-"""Constants for the AWS S3 integration."""
+"""Constants for the Yandex Object Storage integration."""
 
 from collections.abc import Callable
 from typing import Final
@@ -12,12 +12,12 @@ CONF_SECRET_ACCESS_KEY = "secret_access_key"
 CONF_ENDPOINT_URL = "endpoint_url"
 CONF_BUCKET = "bucket"
 
-AWS_DOMAIN = "amazonaws.com"
-DEFAULT_ENDPOINT_URL = f"https://s3.eu-central-1.{AWS_DOMAIN}/"
+YANDEX_DOMAIN = "storage.yandexcloud.net"
+DEFAULT_ENDPOINT_URL = f"https://{YANDEX_DOMAIN}/"
 
 DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(
     f"{DOMAIN}.backup_agent_listeners"
 )
 
-DESCRIPTION_AWS_S3_DOCS_URL = "https://docs.aws.amazon.com/general/latest/gr/s3.html"
+DESCRIPTION_YANDEX_DOCS_URL = "https://cloud.yandex.com/en/docs/storage/s3/api-ref"
 DESCRIPTION_BOTO3_DOCS_URL = "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html"

--- a/components/aws_s3/manifest.json
+++ b/components/aws_s3/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aws_s3_fork",
-  "name": "AWS S3 fork",
+  "name": "Yandex Object Storage",
   "codeowners": ["@dsolomka"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aws_s3",

--- a/components/aws_s3/strings.json
+++ b/components/aws_s3/strings.json
@@ -9,19 +9,19 @@
           "endpoint_url": "Endpoint URL"
         },
         "data_description": {
-          "access_key_id": "Access key ID to connect to AWS S3 API",
-          "secret_access_key": "Secret access key to connect to AWS S3 API",
+          "access_key_id": "Access key ID to connect to Yandex Object Storage",
+          "secret_access_key": "Secret access key to connect to Yandex Object Storage",
           "bucket": "Bucket must already exist and be writable by the provided credentials.",
-          "endpoint_url": "Endpoint URL provided to [Boto3 Session]({boto3_docs_url}). Region-specific [AWS S3 endpoints]({aws_s3_docs_url}) are available in their docs."
+          "endpoint_url": "Endpoint URL provided to [Boto3 Session]({boto3_docs_url}). Yandex Object Storage endpoints can be found in the [documentation]({yandex_docs_url})."
         },
-        "title": "Add AWS S3 bucket"
+        "title": "Add Yandex Object Storage bucket"
       }
     },
     "error": {
       "cannot_connect": "[%key:component::aws_s3::exceptions::cannot_connect::message%]",
       "invalid_bucket_name": "[%key:component::aws_s3::exceptions::invalid_bucket_name::message%]",
       "invalid_credentials": "[%key:component::aws_s3::exceptions::invalid_credentials::message%]",
-      "invalid_endpoint_url": "Invalid endpoint URL. Please make sure it's a valid AWS S3 endpoint URL."
+      "invalid_endpoint_url": "Invalid endpoint URL. Please make sure it's a valid Yandex Object Storage endpoint URL."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"


### PR DESCRIPTION
## Summary
- default to Yandex Object Storage endpoint
- allow any endpoint URL
- update copy to reference Yandex docs

## Testing
- `python -m py_compile components/aws_s3/*.py`

------
https://chatgpt.com/codex/tasks/task_b_683dd0cfbb988325a74a9242686ff9a1